### PR TITLE
Fix: fixed the issue to allow the broadcast receiver to receive broad…

### DIFF
--- a/android/src/main/java/com/nyxprinterreactnative/NyxPrinterModule.kt
+++ b/android/src/main/java/com/nyxprinterreactnative/NyxPrinterModule.kt
@@ -83,7 +83,7 @@ class NyxPrinterModule(private val reactContext: ReactApplicationContext) :
   private fun registerQscScanReceiver() {
     val filter = IntentFilter()
     filter.addAction("com.android.NYX_QSC_DATA")
-    reactContext.registerReceiver(qscReceiver, filter)
+    reactContext.registerReceiver(qscReceiver, filter, Context.RECEIVER_EXPORTED);
   }
 
   private fun unregisterQscReceiver() {


### PR DESCRIPTION
**Issue:** Encountered an error on Android V15 (Emulator) and Android V14 (Real device).

![image](https://github.com/user-attachments/assets/2e8c23ca-70db-41a2-8964-1e83815137aa)

**Solution:** To fix this issue, I updated the following line:

`reactContext.registerReceiver(qscReceiver, filter)`
with
`reactContext.registerReceiver(qscReceiver, filter, Context.RECEIVER_EXPORTED);`

in the `registerQscScanReceiver` function within the `NyxPrinterModule.kt` file.

For more information, please refer to this Stack Overflow thread:

https://stackoverflow.com/questions/77235063/one-of-receiver-exported-or-receiver-not-exported-should-be-specified-when-a-rec

Regards,
Saleheen
